### PR TITLE
Adding support for flutter for web and fixing bug with connectionToken in url query

### DIFF
--- a/example/lib/chatPageViewModel.dart
+++ b/example/lib/chatPageViewModel.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:io';
-
+import 'package:http/http.dart';
 import 'package:signalr_netcore/signalr_client.dart';
 
 import 'main.dart';
@@ -73,9 +73,8 @@ class ChatPageViewModel extends ViewModel {
     print(msg.message);
   }
 
-  void _httpClientCreateCallback(HttpClient httpClient) {
-    httpClient.badCertificateCallback =
-        (X509Certificate cert, String host, int port) => true;
+  void _httpClientCreateCallback(Client httpClient) {
+    HttpOverrides.global = HttpOverrideCertificateVerificationInDev();
   }
 
   Future<void> openChatConnection() async {
@@ -83,7 +82,7 @@ class ChatPageViewModel extends ViewModel {
 
     if (_hubConnection == null) {
       final httpConnectionOptions = new HttpConnectionOptions(
-          httpClient: DartIOHttpClient(logger,
+          httpClient: WebSupportingHttpClient(logger,
               httpClientCreateCallback: _httpClientCreateCallback),
           logger: logger,
           logMessageContent: true);
@@ -139,5 +138,14 @@ class ChatPageViewModelProvider extends ViewModelProvider<ChatPageViewModel> {
     return (context
             .dependOnInheritedWidgetOfExactType<ChatPageViewModelProvider>())
         .viewModel;
+  }
+}
+
+class HttpOverrideCertificateVerificationInDev extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext context) {
+    return super.createHttpClient(context)
+      ..badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,10 +18,9 @@ dependencies:
 
   signalr_netcore:
     path: ../
-    
+
   logging: ^1.0.1
-  w3c_event_source: ^1.0.0
-  rxdart : ^0.18.1  
+  rxdart : ^0.18.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/lib/clients/http_client_browser.dart
+++ b/lib/clients/http_client_browser.dart
@@ -1,0 +1,3 @@
+import 'package:http/browser_client.dart';
+
+final clientWithWebSupport = BrowserClient()..withCredentials = true;

--- a/lib/clients/http_client_default.dart
+++ b/lib/clients/http_client_default.dart
@@ -1,0 +1,3 @@
+import 'package:http/http.dart';
+
+final clientWithWebSupport = Client();

--- a/lib/handshake_protocol.dart
+++ b/lib/handshake_protocol.dart
@@ -53,7 +53,7 @@ class HandshakeProtocol {
 
   // Handshake request is always JSON
   String writeHandshakeRequest(HandshakeRequestMessage handshakeRequest) {
-    return TextMessageFormat.write(json.encode(handshakeRequest));
+    return TextMessageFormat.write(json.encode(handshakeRequest.toJson()));
   }
 
   /// Parse the handshake reponse

--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -177,7 +177,9 @@ class TransportSendQueue {
 
       try {
         await this.transport.send(data);
-        transportResult.complete();
+        if (!transportResult.isCompleted) {
+          transportResult.complete();
+        }
       } catch (error) {
         transportResult.completeError(error);
       }

--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -486,7 +486,7 @@ class HttpConnection implements IConnection {
   }
 
   String _createConnectUrl(String url, String connectionToken) {
-    if (connectionToken != null) {
+    if (connectionToken == null) {
       return url;
     }
 

--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
 
-import 'dartio_http_client.dart';
+import 'web_supporting_http_client.dart';
 import 'errors.dart';
 import 'http_connection_options.dart';
 import 'iconnection.dart';
@@ -237,7 +237,7 @@ class HttpConnection implements IConnection {
     baseUrl = url;
 
     _options = options ?? HttpConnectionOptions();
-    _httpClient = options.httpClient ?? DartIOHttpClient(_logger);
+    _httpClient = options.httpClient ?? WebSupportingHttpClient(_logger);
     _connectionState = ConnectionState.Disconnected;
     _connectionStarted = false;
   }

--- a/lib/hub_connection.dart
+++ b/lib/hub_connection.dart
@@ -548,7 +548,7 @@ class HubConnection {
             _logger?.info("Close message received from server.");
             final closeMessage = message as CloseMessage;
 
-            final error = closeMessage.error != null
+            final Exception error = closeMessage.error != null
                 ? GeneralError(
                     "Server returned an error on close: " + closeMessage.error)
                 : null;
@@ -656,7 +656,7 @@ class HubConnection {
         _logger?.severe(message);
 
         // We don't need to wait on this Promise.
-        _stopPromise = _stopInternal(error: new GeneralError(message));
+        _stopPromise = _stopInternal(error: GeneralError(message));
       }
     } else {
       _logger?.warning(
@@ -720,7 +720,7 @@ class HubConnection {
   _reconnect({Exception error}) async {
     final reconnectStartTime = DateTime.now();
     var previousReconnectAttempts = 0;
-    var retryError = error != null
+    Exception retryError = error != null
         ? error
         : GeneralError("Attempting to reconnect due to a unknown error.");
 

--- a/lib/ihub_protocol.dart
+++ b/lib/ihub_protocol.dart
@@ -65,6 +65,7 @@ class MessageHeaders {
   HashMap<String, String> _headers;
 
   Iterable<String> get names => _headers.keys;
+  HashMap<String, String> get asMap => _headers;
 
   bool get isEmtpy => _headers.length == 0;
 
@@ -88,6 +89,19 @@ class MessageHeaders {
     if (_headers.containsKey(name)) {
       _headers.remove(name);
     }
+  }
+
+  @override
+  String toString() {
+    if (isEmtpy) return '(no headers)';
+
+    String str = '';
+    for (var name in names) {
+      if (str.isNotEmpty) str += ', ';
+      str += '{ $name: ${_headers[name]} }';
+    }
+
+    return str;
   }
 }
 

--- a/lib/json_hub_protocol.dart
+++ b/lib/json_hub_protocol.dart
@@ -40,7 +40,7 @@ class JsonHubProtocol implements IHubProtocol {
     }
 
     final jsonInput = input as String;
-    final hubMessages = [];
+    final List<HubMessageBase> hubMessages = [];
 
     if (input == null) {
       return hubMessages;

--- a/lib/signalr_client.dart
+++ b/lib/signalr_client.dart
@@ -1,6 +1,6 @@
 library signalr_client;
 
-export 'dartio_http_client.dart';
+export 'web_supporting_http_client.dart';
 export 'http_connection.dart';
 export 'http_connection_options.dart';
 export 'hub_connection.dart';

--- a/lib/web_socket_transport.dart
+++ b/lib/web_socket_transport.dart
@@ -52,7 +52,7 @@ class WebSocketTransport implements ITransport {
     _logger?.finest("WebSocket try connecting to '$url'.");
     _webSocket = WebSocketChannel.connect(Uri.parse(url));
     opened = true;
-    websocketCompleter.complete();
+    if (!websocketCompleter.isCompleted) websocketCompleter.complete();
     _logger?.info("WebSocket connected to '$url'.");
     _webSocketListenSub = _webSocket.stream.listen(
       // onData
@@ -77,7 +77,9 @@ class WebSocketTransport implements ITransport {
       // onError
       onError: (Object error) {
         var e = error != null ? error : "Unknown websocket error";
-        websocketCompleter.completeError(e);
+        if (!websocketCompleter.isCompleted) {
+          websocketCompleter.completeError(e);
+        }
       },
 
       // onDone
@@ -89,8 +91,10 @@ class WebSocketTransport implements ITransport {
             onClose();
           }
         } else {
-          websocketCompleter
-              .completeError("There was an error with the transport.");
+          if (!websocketCompleter.isCompleted) {
+            websocketCompleter
+                .completeError("There was an error with the transport.");
+          }
         }
       },
     );

--- a/lib/web_socket_transport.dart
+++ b/lib/web_socket_transport.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'errors.dart';
 import 'itransport.dart';
@@ -14,7 +14,7 @@ class WebSocketTransport implements ITransport {
   Logger _logger;
   AccessTokenFactory _accessTokenFactory;
   bool _logMessageContent;
-  WebSocket _webSocket;
+  WebSocketChannel _webSocket;
   StreamSubscription<Object> _webSocketListenSub;
 
   @override
@@ -50,11 +50,11 @@ class WebSocketTransport implements ITransport {
     var opened = false;
     url = url.replaceFirst('http', 'ws');
     _logger?.finest("WebSocket try connecting to '$url'.");
-    _webSocket = await WebSocket.connect(url);
+    _webSocket = WebSocketChannel.connect(Uri.parse(url));
     opened = true;
     websocketCompleter.complete();
     _logger?.info("WebSocket connected to '$url'.");
-    _webSocketListenSub = _webSocket.listen(
+    _webSocketListenSub = _webSocket.stream.listen(
       // onData
       (Object message) {
         if (_logMessageContent && message is String) {
@@ -67,6 +67,8 @@ class WebSocketTransport implements ITransport {
           try {
             onReceive(message);
           } catch (error) {
+            _logger?.severe(
+                "(WebSockets transport) error calling onReceive, error: $error");
             _close();
           }
         }
@@ -98,15 +100,15 @@ class WebSocketTransport implements ITransport {
 
   @override
   Future<void> send(Object data) {
-    if ((_webSocket != null) && (_webSocket.readyState == WebSocket.open)) {
+    if (_webSocket != null) {
       _logger?.finest(
           "(WebSockets transport) sending data. ${getDataDetail(data, true)}.");
       //_logger?.finest("(WebSockets transport) sending data.");
 
       if (data is String) {
-        _webSocket.add(data);
+        _webSocket.sink.add(data);
       } else if (data is Uint8List) {
-        _webSocket.add(data);
+        _webSocket.sink.add(data);
       } else {
         throw GeneralError("Content type is not handled.");
       }
@@ -130,7 +132,7 @@ class WebSocketTransport implements ITransport {
         await _webSocketListenSub.cancel();
         _webSocketListenSub = null;
       }
-      _webSocket.close();
+      _webSocket.sink.close();
       _webSocket = null;
     }
 

--- a/lib/web_supporting_http_client.dart
+++ b/lib/web_supporting_http_client.dart
@@ -48,8 +48,9 @@ class WebSupportingHttpClient extends SignalRHttpClient {
       final abortFuture = Future<void>(() {
         final completer = Completer<void>();
         if (request.abortSignal != null) {
-          request.abortSignal.onabort =
-              () => completer.completeError(AbortError());
+          request.abortSignal.onabort = () {
+            if (!completer.isCompleted) completer.completeError(AbortError());
+          };
         }
         return completer.future;
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
     sdk: flutter
 
   logging: ^1.0.1
-  w3c_event_source: ^1.3.0
   tuple: ^2.0.0
   http: ^0.13.3
   web_socket_channel: ^2.1.0
+  sse_client: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   logging: ^1.0.1
   w3c_event_source: ^1.3.0
   tuple: ^2.0.0
+  http: ^0.13.3
+  web_socket_channel: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/testapp/client/pubspec.yaml
+++ b/testapp/client/pubspec.yaml
@@ -22,10 +22,8 @@ dependencies:
 
   signalr_netcore:
     path: ../../
-    
-  w3c_event_source: ^1.0.0
 
-  rxdart : ^0.18.1  
+  rxdart : ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* Added support for flutter for web by:
  * Changing HttpClient from dart:io to http package with two separate clients for dart:io supporting devices and for browsers
  * Replacing websocket from dart:io to web_socket_channel package that has support for web
  * Using sse_client instead of w3c_event_source (not sure that this change was really necessary)
* Fixed a bug with connection token that checked != null but the correct check should be == null

I haven't fixed/verified the tests. It wasn't as easy as "flutter test" so I didn't put time into it (yet). I can do that if the tests fail and if the author wants to merge this PR.