### PR TITLE
Removing BrowserClient 

### DIFF
--- a/lib/clients/http_client_browser.dart
+++ b/lib/clients/http_client_browser.dart
@@ -1,3 +1,0 @@
-import 'package:http/browser_client.dart';
-
-final clientWithWebSupport = BrowserClient()..withCredentials = true;

--- a/lib/clients/http_client_default.dart
+++ b/lib/clients/http_client_default.dart
@@ -1,3 +1,0 @@
-import 'package:http/http.dart';
-
-final clientWithWebSupport = Client();

--- a/lib/web_supporting_http_client.dart
+++ b/lib/web_supporting_http_client.dart
@@ -5,8 +5,6 @@ import 'errors.dart';
 import 'signalr_http_client.dart';
 import 'utils.dart';
 import 'package:logging/logging.dart';
-import 'clients/http_client_default.dart'
-    if (dart.library.js) 'clients/http_client_browser.dart';
 
 typedef OnHttpClientCreateCallback = void Function(Client httpClient);
 
@@ -40,7 +38,7 @@ class WebSupportingHttpClient extends SignalRHttpClient {
     return Future<SignalRHttpResponse>(() async {
       final uri = Uri.parse(request.url);
 
-      final httpClient = clientWithWebSupport;
+      final httpClient = Client();
       if (_httpClientCreateCallback != null) {
         _httpClientCreateCallback(httpClient);
       }


### PR DESCRIPTION
Removing BrowserClient because it breaks pub.dev compatibility checks for native applications (even though it works just fine with iOS / Android apps). The benefit of BrowserClient is that it supports http only cookies (response cookies) that are often used in SPA authentication scenarios. But the regular http client supports other types of authentication so this shouldn't be that big of a deal for most users.