### PR TITLE
Change invoke return type on hub_connection

### DIFF
--- a/lib/hub_connection.dart
+++ b/lib/hub_connection.dart
@@ -383,13 +383,13 @@ class HubConnection {
   /// args: The arguments used to invoke the server method.
   /// Returns a Future that resolves with the result of the server method (if any), or rejects with an error.
   ///
-  Future<Object> invoke(String methodName, {List<Object>? args}) {
+  Future<Object?> invoke(String methodName, {List<Object>? args}) {
     args = args ?? [];
     final t = _replaceStreamingParams(args);
     final invocationDescriptor =
         _createInvocation(methodName, args, false, t.item2);
 
-    final completer = Completer<Object>();
+    final completer = Completer<Object?>();
 
     _callbacks[invocationDescriptor.invocationId] =
         (HubMessageBase? invocationEvent, Exception? error) {


### PR DESCRIPTION
Hi,

This PR, fix an error when [CompletionMessage](https://docs.microsoft.com/en-us/javascript/api/@microsoft/signalr/completionmessage?view=signalr-js-latest) doesn't have error and returns null on result property.

Log Error
```
I/flutter ( 8307): (WebSockets transport) data received. message String data of length 44. Content: '{"type":3,"invocationId":"0","result":null}'.
I/flutter ( 8307): (WebSockets transport) error calling onReceive, error: type 'Null' is not a subtype of type 'Object'
I/flutter ( 8307): (WebSockets transport) socket closed.
```