### PR TITLE
Exposes default MessageHeaders for HttpRequests

### DIFF
--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -439,6 +439,8 @@ class HttpConnection implements IConnection {
 
   Future<NegotiateResponse> _getNegotiationResponse(String url) async {
     MessageHeaders headers = MessageHeaders();
+    headers.addMessageHeaders(_options.headers);
+
     if (_accessTokenFactory != null) {
       final token = await _accessTokenFactory!();
       headers.setHeaderValue("Authorization", "Bearer $token");

--- a/lib/http_connection_options.dart
+++ b/lib/http_connection_options.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
 
+import 'ihub_protocol.dart';
 import 'itransport.dart';
 import 'signalr_http_client.dart';
 
@@ -23,6 +24,9 @@ class HttpConnectionOptions {
   /// A function that provides an access token required for HTTP Bearer authentication.
   AccessTokenFactory? accessTokenFactory;
 
+  /// A MessageHeaders that provides default headers for HTTP Requests
+  MessageHeaders? headers;
+
   /// A boolean indicating if message content should be logged.
   ///
   /// Message content can contain sensitive user data, so this is disabled by default.
@@ -41,12 +45,14 @@ class HttpConnectionOptions {
       Object? transport,
       Logger? logger,
       AccessTokenFactory? accessTokenFactory,
+      MessageHeaders? headers,
       bool logMessageContent = false,
       bool skipNegotiation = false})
       : this.httpClient = httpClient,
         this.transport = transport,
         this.logger = logger,
         this.accessTokenFactory = accessTokenFactory,
+        this.headers = headers,
         this.logMessageContent = logMessageContent,
         this.skipNegotiation = skipNegotiation;
 }

--- a/lib/ihub_protocol.dart
+++ b/lib/ihub_protocol.dart
@@ -77,10 +77,19 @@ class MessageHeaders {
     _headers![name] = value;
   }
 
-  /// removes the given header
+  /// Removes the given header
   void removeHeader(String name) {
     if (_headers!.containsKey(name)) {
       _headers!.remove(name);
+    }
+  }
+
+  /// Concatenate message headers
+  void addMessageHeaders(MessageHeaders? newHeaders) {
+    if (newHeaders != null && !newHeaders.isEmtpy) {
+      for (var name in newHeaders.names) {
+        setHeaderValue(name, newHeaders.getHeaderValue(name)!);
+      }
     }
   }
 

--- a/lib/web_supporting_http_client.dart
+++ b/lib/web_supporting_http_client.dart
@@ -66,11 +66,7 @@ class WebSupportingHttpClient extends SignalRHttpClient {
               ? 'application/json;charset=UTF-8'
               : 'text/plain;charset=UTF-8');
 
-      if ((request.headers != null) && (!request.headers!.isEmtpy)) {
-        for (var name in request.headers!.names) {
-          headers.setHeaderValue(name, request.headers!.getHeaderValue(name)!);
-        }
-      }
+      headers.addMessageHeaders(request.headers);
 
       _logger?.finest(
           "HTTP send: url '${request.url}', method: '${request.method}' content: '${request.content}' content length = '${(request.content as String).length}' headers: '$headers'");


### PR DESCRIPTION
Hello,

I am implementing a SignalR Hub that will be managed by APIM Azure.
The company I work for requires a header for monitoring the application but the library doesn't expose any way to send different headers for the HttpRequest, only the accessTokenFactory.

I am openning this pull request to expose a MessageHeaders object so the client can send default headers.

### Code Example
```dart
final defaultHeaders = MessageHeaders();
defaultHeaders.setHeaderValue("HEADER_MOCK_1", "HEADER_VALUE_1");
defaultHeaders.setHeaderValue("HEADER_MOCK_2", "HEADER_VALUE_2");

final httpConnectionOptions = new HttpConnectionOptions(
          httpClient: WebSupportingHttpClient(logger,
              httpClientCreateCallback: _httpClientCreateCallback),
          accessTokenFactory: () => Future.value('JWT_TOKEN'),
          logger: logger,
          logMessageContent: true,
          headers: defaultHeaders);

final _hubConnection = HubConnectionBuilder()
          .withUrl(_serverUrl, options: httpConnectionOptions)
          .withAutomaticReconnect(retryDelays: [2000, 5000, 10000, 20000, null])
          .configureLogging(logger)
          .build();

```

### Http Request Log

```
I/flutter ( 5248): Starting connection with transfer format 'TransferFormat.Text'.
I/flutter ( 5248): Sending negotiation request: https://localhost:5000/negotiate?negotiateVersion=1
I/flutter ( 5248): HTTP send: url 'https://localhost:5000/negotiate?negotiateVersion=1', method: 'POST' content: '' content length = '0' 
headers: '{ content-type: text/plain;charset=UTF-8 }, { HEADER_MOCK_1: HEADER_VALUE_1 }, { X-Requested-With: FlutterHttpClient }, { HEADER_MOCK_2: HEADER_VALUE_2 }, { Authorization: Bearer JWT_TOKEN }'

```






