### PR TITLE
Add Timeout option for requests to resolve unexpected Timeout Exceptions  

### DIFF
--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -197,7 +197,6 @@ class TransportSendQueue {
 class HttpConnection implements IConnection {
   // Properties
   static final maxRedirects = 100;
-  static final maxRequestTimeoutMilliseconds = 2000;
 
   ConnectionState? _connectionState;
   // connectionStarted is tracked independently from connectionState, so we can check if the
@@ -450,9 +449,7 @@ class HttpConnection implements IConnection {
     _logger?.finer("Sending negotiation request: $negotiateUrl");
     try {
       final SignalRHttpRequest options = SignalRHttpRequest(
-          content: "",
-          headers: headers,
-          timeout: maxRequestTimeoutMilliseconds);
+          content: "", headers: headers, timeout: _options.requestTimeout);
       final response = await _httpClient.post(negotiateUrl, options: options);
 
       if (response.statusCode != 200) {

--- a/lib/http_connection_options.dart
+++ b/lib/http_connection_options.dart
@@ -39,6 +39,9 @@ class HttpConnectionOptions {
   ///
   bool skipNegotiation;
 
+  /// An int that reflects the time to wait for a request to complete before throwing a TimeoutError. Measured in milliseconds.
+  int requestTimeout;
+
   // Methods
   HttpConnectionOptions(
       {SignalRHttpClient? httpClient,
@@ -47,12 +50,14 @@ class HttpConnectionOptions {
       AccessTokenFactory? accessTokenFactory,
       MessageHeaders? headers,
       bool logMessageContent = false,
-      bool skipNegotiation = false})
+      bool skipNegotiation = false,
+      int requestTimeout = 2000})
       : this.httpClient = httpClient,
         this.transport = transport,
         this.logger = logger,
         this.accessTokenFactory = accessTokenFactory,
         this.headers = headers,
         this.logMessageContent = logMessageContent,
-        this.skipNegotiation = skipNegotiation;
+        this.skipNegotiation = skipNegotiation,
+        this.requestTimeout = requestTimeout;
 }


### PR DESCRIPTION
Hi,

This PR adds a timeout option for HttpConnectionOptions and defaults to 2000ms.

This mainly addresses issue #18 