### PR TITLE
Fixed broken authorization in Server Sent Events (SSE) transport

### DIFF
--- a/lib/server_sent_events_transport.dart
+++ b/lib/server_sent_events_transport.dart
@@ -61,8 +61,8 @@ class ServerSentEventsTransport implements ITransport {
 
     SseClient client;
     try {
-      client = SseClient.connect(Uri.parse(_url!));
-      _logger?.finer('(SSE transport) connected to $_url');
+      client = SseClient.connect(Uri.parse(url!));
+      _logger?.finer('(SSE transport) connected to $url');
       opened = true;
       _sseClient = client;
     } catch (e) {


### PR DESCRIPTION
When using Server Sent Events (SSE) transport, the access token was not passed in the request to the server. This was causing "user is not authorised" error for subsequent calls to invoke(), etc. 

