### PR TITLE
Allowing invocation arguments to be null

### DIFF
--- a/lib/hub_connection.dart
+++ b/lib/hub_connection.dart
@@ -34,7 +34,7 @@ enum HubConnectionState {
 
 typedef InvocationEventCallback = void Function(
     HubMessageBase? invocationEvent, Exception? error);
-typedef MethodInvocationFunc = void Function(List<Object>? arguments);
+typedef MethodInvocationFunc = void Function(List<Object?>? arguments);
 typedef ClosedCallback = void Function({Exception? error});
 typedef ReconnectingCallback = void Function({Exception? error});
 typedef ReconnectedCallback = void Function({String? connectionId});

--- a/lib/ihub_protocol.dart
+++ b/lib/ihub_protocol.dart
@@ -146,7 +146,7 @@ class InvocationMessage extends HubInvocationMessage {
   final String? target;
 
   /// The target method arguments.
-  final List<Object>? arguments;
+  final List<Object?>? arguments;
 
   /// The target method's stream IDs.
   final List<String>? streamIds;
@@ -154,7 +154,7 @@ class InvocationMessage extends HubInvocationMessage {
   // Methods
   InvocationMessage(
       {String? target,
-      List<Object>? arguments,
+      List<Object?>? arguments,
       List<String>? streamIds,
       MessageHeaders? headers,
       String? invocationId})

--- a/lib/json_hub_protocol.dart
+++ b/lib/json_hub_protocol.dart
@@ -99,7 +99,7 @@ class JsonHubProtocol implements IHubProtocol {
         createMessageHeadersFromJson(jsonData["headers"]);
     final message = InvocationMessage(
         target: jsonData["target"],
-        arguments: jsonData["arguments"]?.cast<Object>().toList(),
+        arguments: jsonData["arguments"]?.cast<Object?>().toList(),
         streamIds: (jsonData["streamIds"] == null)
             ? null
             : (List<String>.from(jsonData["streamIds"] as List<dynamic>)),


### PR DESCRIPTION
According to the SignalR spec, they rely on the respective serializers for mapping types. They have a listing of types, but say it is not exhaustive. This change allows for invocation arguments to be a null type. Without this, the client crashes when it tries to cast to Object.