### PR TITLE
Added back web with no headers support

### DIFF
--- a/lib/web_socket_transport.dart
+++ b/lib/web_socket_transport.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
-import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'dart:io' as io;
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
@@ -53,8 +54,12 @@ class WebSocketTransport implements ITransport {
     _logger?.finest("WebSocket try connecting to '$url'.");
 
     try {
-      final webSocket = await WebSocket.connect(url, headers: headers);
-      _webSocket = IOWebSocketChannel(webSocket);
+      if (kIsWeb) {
+        _webSocket = WebSocketChannel.connect(Uri.parse(url));
+      } else {
+        final webSocket = await io.WebSocket.connect(url, headers: headers);
+        _webSocket = IOWebSocketChannel(webSocket);
+      }
       opened = true;
       if (!websocketCompleter.isCompleted) websocketCompleter.complete();
       _logger?.info("WebSocket connected to '$url'.");


### PR DESCRIPTION
Adding back web support that was removed by #93

Websocket on browser doesn't support passing headers, instead the token must be passed via query string in the url.

I'm leaving that upto the developer to pass that in whatever shape they want.

This is a fix for #96 