### PR TITLE
Adds message headers to the web socket transport

### DIFF
--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -556,7 +556,7 @@ class HttpConnection implements IConnection {
     switch (transport) {
       case HttpTransportType.WebSockets:
         return WebSocketTransport(
-            _accessTokenFactory, _logger, _options.logMessageContent);
+            _accessTokenFactory, _logger, _options.logMessageContent, _options.headers);
       case HttpTransportType.ServerSentEvents:
         return new ServerSentEventsTransport(_httpClient, _accessTokenFactory,
             _logger, _options.logMessageContent);

--- a/lib/web_socket_transport.dart
+++ b/lib/web_socket_transport.dart
@@ -3,6 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'dart:io' as io;
 
 import 'package:logging/logging.dart';
+import 'package:signalr_netcore/ihub_protocol.dart';
+import 'package:signalr_netcore/signalr_client.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -18,6 +20,7 @@ class WebSocketTransport implements ITransport {
   final bool _logMessageContent;
   WebSocketChannel? _webSocket;
   StreamSubscription<Object?>? _webSocketListenSub;
+  MessageHeaders? _headers;
 
   @override
   OnClose? onClose;
@@ -27,10 +30,11 @@ class WebSocketTransport implements ITransport {
 
   // Methods
   WebSocketTransport(AccessTokenFactory? accessTokenFactory, Logger? logger,
-      bool logMessageContent)
+      bool logMessageContent, MessageHeaders? headers)
       : _accessTokenFactory = accessTokenFactory,
         _logger = logger,
-        _logMessageContent = logMessageContent;
+        _logMessageContent = logMessageContent,
+        _headers = headers;
 
   @override
   Future<void> connect(String? url, TransferFormat transferFormat) async {
@@ -38,7 +42,7 @@ class WebSocketTransport implements ITransport {
 
     _logger?.finest("(WebSockets transport) Connecting");
 
-    Map<String, dynamic> headers = {};
+    Map<String, String> headers = _headers?.asMap ?? {};
 
     if (_accessTokenFactory != null) {
       final token = await _accessTokenFactory!();


### PR DESCRIPTION
Dear Farshid,

First of all. Thank your for maintaining this library. It’s great being able to use SignalR with flutter.

I ran into a small issue that others have commented on before and I thought I have a try at fixing it and bringing it upstream. 

So for context. As mentioned in issue #73 and #107. When the web socket is initialised it didn’t send along the headers that were given in the HttpConnectionOptions. So when you try to look them up like for instance: 

```
public override async Task OnConnectedAsync()
{
    var context = Context.GetHttpContext();

    if (context != null && context.Request.Headers.TryGetValue("HEADER_MOCK_1", out StringValues value))
    {
        // **value** is not found.
    }
    await base.OnConnectedAsync();
}
```
The custom headers that were added weren’t there or on the any other invocation. With this modification the headers will be sent along with both. 

I have tested this with our in house product and decided to bring it upstream. 

If you have any further questions do let me know. I’m sure we can work this out.

Tom