### PR TITLE
Add headers to the long polling transport

### DIFF
--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -555,14 +555,14 @@ class HttpConnection implements IConnection {
   ITransport _constructTransport(HttpTransportType transport) {
     switch (transport) {
       case HttpTransportType.WebSockets:
-        return WebSocketTransport(
-            _accessTokenFactory, _logger, _options.logMessageContent, _options.headers);
+        return WebSocketTransport(_accessTokenFactory, _logger,
+            _options.logMessageContent, _options.headers);
       case HttpTransportType.ServerSentEvents:
         return new ServerSentEventsTransport(_httpClient, _accessTokenFactory,
             _logger, _options.logMessageContent);
       case HttpTransportType.LongPolling:
         return LongPollingTransport(_httpClient, _accessTokenFactory, _logger,
-            _options.logMessageContent);
+            _options.logMessageContent, _options.headers);
       default:
         throw new GeneralError("Unknown transport: $transport.");
     }

--- a/lib/http_connection.dart
+++ b/lib/http_connection.dart
@@ -556,7 +556,7 @@ class HttpConnection implements IConnection {
     switch (transport) {
       case HttpTransportType.WebSockets:
         return WebSocketTransport(
-            _accessTokenFactory, _logger, _options.logMessageContent);
+            _accessTokenFactory, _logger, _options.logMessageContent, _options.headers);
       case HttpTransportType.ServerSentEvents:
         return new ServerSentEventsTransport(_httpClient, _accessTokenFactory,
             _logger, _options.logMessageContent);

--- a/lib/long_polling_transport.dart
+++ b/lib/long_polling_transport.dart
@@ -16,6 +16,7 @@ class LongPollingTransport implements ITransport {
   final Logger? _logger;
   final bool _logMessageContent;
   final AbortController _pollAbort;
+  MessageHeaders? _headers;
 
   bool? get pollAborted => _pollAbort.aborted;
 
@@ -36,11 +37,13 @@ class LongPollingTransport implements ITransport {
       SignalRHttpClient httpClient,
       AccessTokenFactory? accessTokenFactory,
       Logger? logger,
-      bool logMessageContent)
+      bool logMessageContent,
+      MessageHeaders? headers)
       : _httpClient = httpClient,
         _accessTokenFactory = accessTokenFactory,
         _logger = logger,
         _logMessageContent = logMessageContent,
+        _headers = headers,
         _pollAbort = AbortController() {
     _running = false;
   }
@@ -60,7 +63,7 @@ class LongPollingTransport implements ITransport {
 
     final pollOptions = SignalRHttpRequest(
         abortSignal: _pollAbort.signal,
-        headers: MessageHeaders(),
+        headers: _headers ?? MessageHeaders(),
         timeout: 100000);
 
     final token = await _getAccessToken();

--- a/lib/long_polling_transport.dart
+++ b/lib/long_polling_transport.dart
@@ -162,7 +162,7 @@ class LongPollingTransport implements ITransport {
           new GeneralError("Cannot send until the transport is connected"));
     }
     await sendMessage(_logger, "LongPolling", _httpClient, _url,
-        _accessTokenFactory, data, _logMessageContent);
+        _accessTokenFactory, data, _logMessageContent, _headers);
   }
 
   @override

--- a/lib/long_polling_transport.dart
+++ b/lib/long_polling_transport.dart
@@ -180,7 +180,10 @@ class LongPollingTransport implements ITransport {
       _logger
           ?.finest("(LongPolling transport) sending DELETE request to $_url.");
 
-      final deleteOptions = SignalRHttpRequest();
+      final deleteOptions = SignalRHttpRequest(
+        headers: _headers ?? MessageHeaders(),
+      );
+
       final token = await _getAccessToken();
       _updateHeaderToken(deleteOptions, token);
       await _httpClient.delete(_url, options: deleteOptions);

--- a/lib/server_sent_events_transport.dart
+++ b/lib/server_sent_events_transport.dart
@@ -102,6 +102,7 @@ class ServerSentEventsTransport implements ITransport {
       _accessTokenFactory,
       data,
       _logMessageContent,
+      null,
     );
   }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -52,12 +52,13 @@ Future<void> sendMessage(
     String? url,
     AccessTokenFactory? accessTokenFactory,
     Object content,
-    bool logMessageContent) async {
-  MessageHeaders headers = MessageHeaders();
+    bool logMessageContent,
+    MessageHeaders? headers) async {
+  MessageHeaders _headers = headers ?? MessageHeaders();
   if (accessTokenFactory != null) {
     final token = await accessTokenFactory();
     if (!isStringEmpty(token)) {
-      headers.setHeaderValue("Authorization", "Bearer $token");
+      _headers.setHeaderValue("Authorization", "Bearer $token");
     }
   }
 
@@ -66,7 +67,7 @@ Future<void> sendMessage(
 
   //final responseType = content is String ? "arraybuffer" : "text";
   SignalRHttpRequest req =
-      SignalRHttpRequest(content: content, headers: headers);
+      SignalRHttpRequest(content: content, headers: _headers);
   final response = await httpClient.post(url, options: req);
 
   logger?.finest(

--- a/lib/web_socket_transport.dart
+++ b/lib/web_socket_transport.dart
@@ -3,6 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'dart:io' as io;
 
 import 'package:logging/logging.dart';
+import 'package:signalr_netcore/ihub_protocol.dart';
+import 'package:signalr_netcore/signalr_client.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -18,6 +20,7 @@ class WebSocketTransport implements ITransport {
   final bool _logMessageContent;
   WebSocketChannel? _webSocket;
   StreamSubscription<Object?>? _webSocketListenSub;
+  MessageHeaders? _headers;
 
   @override
   OnClose? onClose;
@@ -27,10 +30,11 @@ class WebSocketTransport implements ITransport {
 
   // Methods
   WebSocketTransport(AccessTokenFactory? accessTokenFactory, Logger? logger,
-      bool logMessageContent)
+      bool logMessageContent, MessageHeaders? headers)
       : _accessTokenFactory = accessTokenFactory,
         _logger = logger,
-        _logMessageContent = logMessageContent;
+        _logMessageContent = logMessageContent,
+        _headers = headers;
 
   @override
   Future<void> connect(String? url, TransferFormat transferFormat) async {
@@ -38,7 +42,7 @@ class WebSocketTransport implements ITransport {
 
     _logger?.finest("(WebSockets transport) Connecting");
 
-    Map<String, dynamic> headers = {};
+    Map<String, String> headers = _headers?.asMap ?? {};
 
     if (_accessTokenFactory != null) {
       final token = await _accessTokenFactory!();


### PR DESCRIPTION
I’m using `LongPollingTransport` and needed to add a `User-Agent` header to the request. However, `setHeaderValue` had no effect in this case.

I came across PR #114 _(Thanks to the author for the idea and initial implementation)_, which fixed a similar issue for WebSocketTransport. I used that PR as a foundation — I copied the relevant parts and adapted them to work with LongPollingTransport, adding my own changes where necessary.

Here’s how I configure the connection:
```dart
final serverUrl =
    '${hostUrl}signalr/hubs/AccountEventsHub?clientID=$clientID';
final headers = MessageHeaders();
headers.setHeaderValue(
  'User-Agent',
  httpClient.config.headers?['User-Agent'],
);

final httpOptions = HttpConnectionOptions(
  transport: HttpTransportType.LongPolling,
  headers: headers,
);

final hubConnection = HubConnectionBuilder()
    .withUrl(serverUrl, options: httpOptions)
    .withAutomaticReconnect()
    .build();
...
```